### PR TITLE
fix case insensitivity for non-windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Forget generic AI chat tools. **TensorBlock Studio** is a new kind of workspace 
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/TensorBlock/TensorBlock-Studio.git
+   git clone https://github.com/TensorBlock/TensorBlock-Studio.git tensorblock-studio
    cd tensorblock-studio
    ```
 


### PR DESCRIPTION
`git clone https://github.com/TensorBlock/TensorBlock-Studio.git` clones into `TensorBlock-Studio`.
On a system where you can assume `bash` to be installed, `cd tensorblock-studio` wouldn't work because the UNIX standard specifies directories to be case sensitive.

This fixes that issue by cloning into `tensorblock-studio` specifically. I chose this method rather than `cd TensorBlock-Studio` because it is more verbose and therefore self-explanatory.